### PR TITLE
fix: 소셜 계정 연동 플로우의 state 및 userId 관리 정교화

### DIFF
--- a/src/main/kotlin/com/devpilot/backend/common/controller/AuthenticationController.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/controller/AuthenticationController.kt
@@ -65,7 +65,7 @@ class AuthenticationController(
         println("🔗 계정 연동 요청: userId = $userId, provider = google")
 
         // state를 위한 랜덤 값 생성
-        val stateToken = "bind:" + UUID.randomUUID().toString()
+        val stateToken = "bind:${UUID.randomUUID()}"
 
         // 세션에 userId <-> state 매핑 저장 (예: request.session.setAttribute("bind:<UUID>", userId))
         request.session.setAttribute(stateToken, userId)


### PR DESCRIPTION
- **문제점:** 계정 연동 요청 시 사용자(`userId`) 정보가 세션에서 올바르게 조회되지 않아 연동 로직이 아닌 일반 소셜 로그인 로직이 실행되던 문제 해결. `state` 파라미터 전달 방식의 불일치로 인한 복잡성 개선.

- **주요 변경 사항:**
    - **컨트롤러 (`/api/auth/bind/google`):** - 현재 로그인된 사용자의 `userId`를 고유한 `bind:UUID` 문자열을 **키**로 사용하여 세션에 직접 저장. (`request.session.setAttribute("bind:UUID", userId)`) - Google 인증 시작 URL로 리다이렉트 시, `bind:UUID`를 `my_custom_bind_state`라는 **새로운 쿼리 파라미터 이름**으로 명확히 전달. (Spring Security의 표준 `state` 파라미터와 분리)
    - **`CustomAuthorizationRequestRepository`:**
        - `saveAuthorizationRequest` 메서드에서 Spring Security가 생성한 `originalSpringSecurityState`와 `my_custom_bind_state` 파라미터를 통해 전달받은 `bind:UUID`를 확인.
        - 이 요청이 연동 요청임을 나타내기 위해 `IS_BINDING_REQUEST_FLAG_originalSSState`라는 고유한 세션 키 아래에 `true` **플래그만** 저장. (이전의 복잡한 Map 저장 로직 및 `userId` 조회 시도 제거) - `removeAuthorizationRequest`에서 Spring Security의 기본 인증 요청 객체(`SESSION_ATTR_NAME`)만 제거하고, 연동 요청 플래그는 `CustomOidcUserService`가 처리하도록 책임 이관.
    - **`CustomOidcUserService`:** - `loadUser` 메서드에서 Google로부터 반환된 `state`를 사용하여 세션에서 `IS_BINDING_REQUEST_FLAG_originalSSState` 플래그를 조회하여 연동 요청임을 식별. - 연동 요청으로 식별되면, 세션에 남아있는 속성 이름들 중에서 "bind:"로 시작하는 (`bind:UUID` 형태의) 키를 찾아 `bindSocialAccount` 메서드에 전달. - `bindSocialAccount` 메서드는 전달받은 `bind:UUID` 키를 사용하여 세션에서 `userId`를 정확히 조회하도록 로직을 일치시킴. 사용된 `bind:UUID -> userId` 매핑은 세션에서 제거.

- **개선 효과:**
    - 계정 연동 요청이 올바르게 식별되고, `userId`와 `bind:UUID` 정보가 세션에서 정확하게 관리 및 조회됨으로써 `INVALID_BINDING_REQUEST` 오류 해결.
    - `state` 파라미터 관리의 각 컴포넌트 간 책임이 명확해지고 데이터 흐름이 단순화되어 코드의 견고성 향상.