### PR TITLE
fix: 소셜 계정 연동 플로우의 state 및 userId 관리 재구축

### DIFF
--- a/src/main/kotlin/com/devpilot/backend/common/controller/AuthenticationController.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/controller/AuthenticationController.kt
@@ -60,20 +60,17 @@ class AuthenticationController(
         response: HttpServletResponse,
         authentication: Authentication
     ): BaseResponse<String> {
-        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+        val currentUserId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
             ?: throw UserNotFoundException()
-        println("🔗 계정 연동 요청: userId = $userId, provider = google")
+        println("🔗 계정 연동 요청: userId = $currentUserId, provider = google")
 
         // state를 위한 랜덤 값 생성
-        val stateToken = "bind:${UUID.randomUUID()}"
-
-        // 세션에 userId <-> state 매핑 저장 (예: request.session.setAttribute("bind:<UUID>", userId))
-        request.session.setAttribute(stateToken, userId)
-        println("🧩 저장된 state = $stateToken → userId = $userId")
+        val bindingStateToken = "bind:${UUID.randomUUID()}"
 
         val redirectUri = UriComponentsBuilder
             .fromUriString("$beBaseUrl/oauth2/authorization/google")
-            .queryParam("my_custom_bind_state", stateToken)
+            .queryParam("binding_user_id", currentUserId)
+            .queryParam("binding_state_token", bindingStateToken)
             .build().toUriString()
 
         return BaseResponse.success(data = redirectUri)


### PR DESCRIPTION
- **문제점:** 이전 구현에서 계정 연동(`bindSocialAccount`) 시 `userId`가 세션에서 올바르게 조회되지 않던 문제 해결. 이는 컨트롤러가 `userId`를 세션에 직접 저장하는 방식과 `CustomAuthorizationRequestRepository`, `CustomOidcUserService` 간의 데이터 흐름 및 세션 키 관리 불일치로 인해 발생했습니다.

- **주요 변경 사항:**
    - **`MemberController` (컨트롤러):** - 현재 로그인된 사용자의 `userId`를 세션에 직접 저장하는 기존 로직 (`request.session.setAttribute(stateToken, currentUserId)`)을 **제거**했습니다. - Google 인증 시작 URL로 리다이렉트 시, `currentUserId`는 `binding_user_id` 쿼리 파라미터로, `bind:UUID` 형태의 `bindingStateToken`은 `binding_state_token` 쿼리 파라미터로 **명시적으로 전달**하도록 변경했습니다. 이는 Spring Security의 표준 `state` 파라미터와 독립적으로 커스텀 데이터를 전달하기 위함입니다.
    - **`CustomAuthorizationRequestRepository`:**
        - `IS_BINDING_REQUEST_FLAG` 상수를 더 이상 사용하지 않고, `SPRING_SECURITY_OAUTH2_BINDING_DATA` 상수를 도입했습니다.
        - `saveAuthorizationRequest` 시, 컨트롤러로부터 전달받은 `binding_user_id`와 `binding_state_token` 파라미터를 가져옵니다. - 이 두 값을 `bindState` 및 `userId` 키를 갖는 `Map` 형태로 구성하고, Spring Security의 `originalSpringSecurityState`와 조합된 `SPRING_SECURITY_OAUTH2_BINDING_DATA_originalSSState`라는 고유한 세션 키 아래에 **이 Map을 저장**합니다. 이 Map이 연동 요청에 필요한 모든 정보를 통합 관리하는 유일한 출처가 됩니다. - `removeAuthorizationRequest`에서 해당 `Map` 형태의 연동 데이터를 정확히 제거하도록 수정했습니다.
    - **`CustomOidcUserService`:** - `loadUser` 메서드에서 `IS_BINDING_REQUEST_FLAG` 관련 로직을 제거하고, `SPRING_SECURITY_OAUTH2_BINDING_DATA` 상수를 사용합니다. - Google로부터 반환된 `state` (즉, `originalSpringSecurityState`)를 사용하여 세션에서 `SPRING_SECURITY_OAUTH2_BINDING_DATA_returnedSSState` 키의 `Map`을 조회합니다. - 이 `Map`에서 `bindState`와 `userId`를 정확히 추출하여 `bindSocialAccount` 메서드에 전달하도록 로직을 변경했습니다. - `bindSocialAccount` 메서드는 이제 이 `Map`을 직접 인수로 받아 `userId`와 `bindState`에 안전하게 접근합니다. (`request.session.removeAttribute(bindState)`와 같은 이전의 불필요한 세션 삭제 로직은 제거되었습니다.)

- **개선 효과:**
    - 소셜 계정 연동 흐름에서 `userId` 및 `bind:UUID` 데이터가 세션에 일관되고 견고하게 저장 및 조회됩니다.
    - `INVALID_BINDING_REQUEST` 오류가 해결되어 연동 로직이 올바르게 실행됩니다.
    - 각 컴포넌트(`Controller`, `AuthorizationRequestRepository`, `OidcUserService`) 간의 데이터 전달 및 세션 관리 책임이 명확해져 코드의 유지보수성과 신뢰성이 향상됩니다.