### PR TITLE
feat: 태스크 하위 관계 및 이전 상태 저장 기능 구현

### DIFF
--- a/src/main/kotlin/com/devpilot/backend/task/dto/TaskCreateRequest.kt
+++ b/src/main/kotlin/com/devpilot/backend/task/dto/TaskCreateRequest.kt
@@ -13,4 +13,5 @@ data class TaskCreateRequest(
     val status: TaskStatus,
     val parentId: Long?,
     val projectId: Long? = null,
+    val previousStatus: TaskStatus? = null,
 )

--- a/src/main/kotlin/com/devpilot/backend/task/dto/TaskResponse.kt
+++ b/src/main/kotlin/com/devpilot/backend/task/dto/TaskResponse.kt
@@ -17,4 +17,5 @@ data class TaskResponse(
     val estimatedTimeHours: Double?,
     val createdDate: LocalDateTime?,
     val lastModifiedDate: LocalDateTime?,
+    val previousStatus: TaskStatus?,
 )

--- a/src/main/kotlin/com/devpilot/backend/task/dto/TaskUpdateRequest.kt
+++ b/src/main/kotlin/com/devpilot/backend/task/dto/TaskUpdateRequest.kt
@@ -11,5 +11,6 @@ data class TaskUpdateRequest(
     val priority: Int?,
     val dueDate: LocalDate?,
     val estimatedTimeHours: Double?,
-    val actualTimeHours: Double?
+    val actualTimeHours: Double?,
+    val previousStatus: TaskStatus?
 )

--- a/src/main/kotlin/com/devpilot/backend/task/entity/Task.kt
+++ b/src/main/kotlin/com/devpilot/backend/task/entity/Task.kt
@@ -53,6 +53,9 @@ data class Task(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     var project: Project? = null,
+
+    @Enumerated(EnumType.STRING)
+    var previousStatus: TaskStatus? = null,
 ): BaseEntity() {
     fun toResponse() = TaskResponse(
         id = id,
@@ -67,6 +70,7 @@ data class Task(
         estimatedTimeHours = estimatedTimeHours,
         createdDate = createdDate,
         lastModifiedDate = lastModifiedDate,
+        previousStatus = previousStatus
     )
 }
 


### PR DESCRIPTION
- `Task` 엔티티 및 `TaskCreateRequest`, `TaskUpdateRequest`, `TaskResponse` DTO에 `parentId`와 `previousStatus` 필드 추가.
- `TaskService.createTask` 및 `TaskService.updateTask` 메서드 로직 개선: `parentId`와 `previousStatus`를 엔티티에 올바르게 반영.
- `TaskService.updateTaskStatus` 메서드 개선: 태스크 상태 변경 시 `previousStatus`를 활용하여 이전 상태로의 복구 로직 지원 및 `null` 값 처리 개선.