### PR TITLE
feat: JWT 토큰 갱신 및 태스크 계층 관계 관리 시스템 강화

### DIFF
--- a/src/main/kotlin/com/devpilot/backend/common/authority/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/authority/CustomAuthenticationEntryPoint.kt
@@ -1,28 +1,37 @@
 package com.devpilot.backend.common.authority
 
+import com.devpilot.backend.common.dto.BaseResponse
+import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.AuthenticationEntryPoint
 import java.io.IOException
 
-class CustomAuthenticationEntryPoint : AuthenticationEntryPoint {
+class CustomAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper
+) : AuthenticationEntryPoint {
     @Throws(IOException::class)
     override fun commence(
         request: HttpServletRequest?,
         response: HttpServletResponse,
         authException: AuthenticationException?,
     ) {
-//        // 리디렉션 URL 설정
-//        val redirectUrl = "/api/member/login"
-//
-//        println("redirect to login")
-//
-//        // 클라이언트로 리디렉션
-//        response.sendRedirect(redirectUrl)
-//
-        // 401 상태 코드와 메시지를 클라이언트로 전송
-        response.sendError(HttpStatus.UNAUTHORIZED.value(), "Unauthorized: Token has expired.")
+        // 인증 실패 시 (401 Unauthorized) 응답 설정
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.characterEncoding = "UTF-8"
+
+        val errorResponse = BaseResponse.error<Any>(
+            code = "ACCESS_TOKEN_EXPIRED",
+            message = "Access Token이 만료되었습니다. Refresh Token으로 갱신이 필요합니다.",
+            status = HttpStatus.UNAUTHORIZED.value(),
+            data = null // 필요시 추가 데이터
+        )
+
+        // JSON 직렬화하여 응답 본문에 쓰기
+        objectMapper.writeValue(response.writer, errorResponse)
     }
 }

--- a/src/main/kotlin/com/devpilot/backend/common/authority/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/authority/JwtTokenProvider.kt
@@ -115,7 +115,7 @@ class JwtTokenProvider {
         return false
     }
 
-    private fun getClaims(token: String): Claims =
+    fun getClaims(token: String): Claims =
         Jwts
             .parserBuilder()
             .setSigningKey(key)

--- a/src/main/kotlin/com/devpilot/backend/common/authority/OAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/authority/OAuth2SuccessHandler.kt
@@ -53,7 +53,7 @@ class OAuth2SuccessHandler(
             isHttpOnly = true
             secure = true
             path = "/"
-            maxAge = 60 * 60 * 24 * 7
+            maxAge = (REFRESH_EXPIRATION_MILLISECONDS / 1000).toInt()
         })
 
         val redirectUri = UriComponentsBuilder

--- a/src/main/kotlin/com/devpilot/backend/common/authority/SecurityConfig.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/authority/SecurityConfig.kt
@@ -3,6 +3,7 @@ package com.devpilot.backend.common.authority
 import com.devpilot.backend.common.ratelimit.RateLimitFilter
 import com.devpilot.backend.common.repository.CustomAuthorizationRequestRepository
 import com.devpilot.backend.member.service.CustomOidcUserService
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -30,6 +31,7 @@ class SecurityConfig(
     private val customOidcUserService: CustomOidcUserService,
     private val oAuth2SuccessHandler: OAuth2SuccessHandler,
     private val oAuth2FailureHandler: OAuth2FailureHandler,
+    private val objectMapper: ObjectMapper,
 ) {
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
@@ -80,7 +82,7 @@ class SecurityConfig(
     }
 
     @Bean
-    fun customAuthenticationEntryPoint(): AuthenticationEntryPoint = CustomAuthenticationEntryPoint()
+    fun customAuthenticationEntryPoint(): AuthenticationEntryPoint = CustomAuthenticationEntryPoint(objectMapper)
 
     @Bean
     fun passwordEncoder(): PasswordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder()

--- a/src/main/kotlin/com/devpilot/backend/common/authority/TokenInfo.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/authority/TokenInfo.kt
@@ -6,4 +6,5 @@ import lombok.NoArgsConstructor
 data class TokenInfo(
     val grantType: String,
     var accessToken: String,
+    val refreshToken: String,
 )

--- a/src/main/kotlin/com/devpilot/backend/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/exception/GlobalExceptionHandler.kt
@@ -1,55 +1,63 @@
 package com.devpilot.backend.common.exception
 
 import com.devpilot.backend.common.dto.BaseResponse
-import com.devpilot.backend.common.exception.exceptions.DuplicateLoginIdException
-import com.devpilot.backend.common.exception.exceptions.ProjectNotFoundException
-import com.devpilot.backend.common.exception.exceptions.TaskNotFoundException
-import com.devpilot.backend.common.exception.exceptions.UserNotFoundException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
 
-    @ExceptionHandler(DuplicateLoginIdException::class)
-    fun handleDuplicateLoginIdException(ex: DuplicateLoginIdException): ResponseEntity<BaseResponse<Nothing>> {
-        val response = BaseResponse.error<Nothing>(
+    // ✨ 모든 CustomException을 처리하는 단일 핸들러
+    @ExceptionHandler(CustomException::class)
+    fun handleCustomException(ex: CustomException): ResponseEntity<BaseResponse<Nothing>> {
+        val response = BaseResponse.error(
             code = ex.resultCode,
             message = ex.message,
-            status = HttpStatus.CONFLICT.value()
+            status = ex.httpStatus.value(),
+            data = null
         )
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(response)
+        return ResponseEntity.status(ex.httpStatus).body(response)
     }
 
-    @ExceptionHandler(ProjectNotFoundException::class)
-    fun handleProjectNotFoundException(ex: ProjectNotFoundException): ResponseEntity<BaseResponse<Nothing>> {
+    // ✨ HttpMessageNotReadableException (JSON 요청 본문 파싱 오류)
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadableException(ex: HttpMessageNotReadableException): ResponseEntity<BaseResponse<Nothing>> {
         val response = BaseResponse.error<Nothing>(
-            code = ex.resultCode,
-            message = ex.message,
-            status = HttpStatus.CONFLICT.value()
+            code = "INVALID_REQUEST_BODY",
+            message = "요청 본문 형식이 올바르지 않습니다. 요청 필드를 확인해주세요.",
+            status = HttpStatus.BAD_REQUEST.value()
         )
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(response)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response)
     }
 
-    @ExceptionHandler(TaskNotFoundException::class)
-    fun handleTaskNotFoundException(ex: TaskNotFoundException): ResponseEntity<BaseResponse<Nothing>> {
+    // ✨ @Valid 검증 실패 시 (선택적, DTO 유효성 검사 오류 처리)
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationExceptions(ex: MethodArgumentNotValidException): ResponseEntity<BaseResponse<Nothing>> {
+        val errors = ex.bindingResult.fieldErrors
+            .map { "${it.field}: ${it.defaultMessage}" }
+            .joinToString(", ")
         val response = BaseResponse.error<Nothing>(
-            code = ex.resultCode,
-            message = ex.message,
-            status = HttpStatus.CONFLICT.value()
+            code = "VALIDATION_FAILED",
+            message = "입력 값 유효성 검증에 실패했습니다: $errors",
+            status = HttpStatus.BAD_REQUEST.value()
         )
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(response)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response)
     }
 
-    @ExceptionHandler(UserNotFoundException::class)
-    fun handleUserNotFoundException(ex: UserNotFoundException): ResponseEntity<BaseResponse<Nothing>> {
+    // ✨ 기타 예상치 못한 모든 RuntimeException 처리 (제일 마지막에)
+    @ExceptionHandler(RuntimeException::class)
+    fun handleRuntimeException(ex: RuntimeException): ResponseEntity<BaseResponse<Nothing>> {
+        // 실제 운영 환경에서는 스택 트레이스 등 상세한 오류 정보를 로그로 남기는 것이 중요합니다.
+        ex.printStackTrace() // 개발/디버깅용, 운영에서는 사용 주의
         val response = BaseResponse.error<Nothing>(
-            code = ex.resultCode,
-            message = ex.message,
-            status = HttpStatus.CONFLICT.value()
+            code = "INTERNAL_SERVER_ERROR",
+            message = "서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+            status = HttpStatus.INTERNAL_SERVER_ERROR.value()
         )
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(response)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response)
     }
 }

--- a/src/main/kotlin/com/devpilot/backend/common/exception/exceptions/DuplicateLoginIdException.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/exception/exceptions/DuplicateLoginIdException.kt
@@ -3,9 +3,8 @@ package com.devpilot.backend.common.exception.exceptions
 import com.devpilot.backend.common.exception.CustomException
 import org.springframework.http.HttpStatus
 
-class DuplicateLoginIdException :
-    CustomException(
+class DuplicateLoginIdException : CustomException(
     resultCode = "DUPLICATE_LOGIN_ID",
     message = "이미 등록된 ID입니다.",
     httpStatus = HttpStatus.CONFLICT,  // 409 Conflict
-    )
+)

--- a/src/main/kotlin/com/devpilot/backend/common/exception/exceptions/ProjectNotFoundException.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/exception/exceptions/ProjectNotFoundException.kt
@@ -3,9 +3,8 @@ package com.devpilot.backend.common.exception.exceptions
 import com.devpilot.backend.common.exception.CustomException
 import org.springframework.http.HttpStatus
 
-class ProjectNotFoundException :
-    CustomException(
-        resultCode = "PROJECT_NOT_FOUND",
-        message = "프로젝트를 찾을 수 없습니다.",
-        httpStatus = HttpStatus.UNAUTHORIZED,
-    )
+class ProjectNotFoundException : CustomException(
+    resultCode = "PROJECT_NOT_FOUND",
+    message = "프로젝트를 찾을 수 없습니다.",
+    httpStatus = HttpStatus.UNAUTHORIZED,
+)

--- a/src/main/kotlin/com/devpilot/backend/common/exception/exceptions/TaskNotFoundException.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/exception/exceptions/TaskNotFoundException.kt
@@ -3,9 +3,8 @@ package com.devpilot.backend.common.exception.exceptions
 import com.devpilot.backend.common.exception.CustomException
 import org.springframework.http.HttpStatus
 
-class TaskNotFoundException :
-    CustomException(
-        resultCode = "TASK_NOT_FOUND",
-        message = "해당 일정을 찾을 수 없습니다.",
-        httpStatus = HttpStatus.UNAUTHORIZED,
-    )
+class TaskNotFoundException : CustomException(
+    resultCode = "TASK_NOT_FOUND",
+    message = "해당 일정을 찾을 수 없습니다.",
+    httpStatus = HttpStatus.NOT_FOUND,
+)

--- a/src/main/kotlin/com/devpilot/backend/common/exception/exceptions/TokenValidationException.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/exception/exceptions/TokenValidationException.kt
@@ -1,0 +1,10 @@
+package com.devpilot.backend.common.exception.exceptions
+
+import com.devpilot.backend.common.exception.CustomException
+import org.springframework.http.HttpStatus
+
+class TokenValidationException(
+    resultCode: String,
+    message: String,
+    httpStatus: HttpStatus = HttpStatus.UNAUTHORIZED
+) : CustomException(resultCode, message, httpStatus)

--- a/src/main/kotlin/com/devpilot/backend/common/exception/exceptions/UserNotFoundException.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/exception/exceptions/UserNotFoundException.kt
@@ -3,9 +3,8 @@ package com.devpilot.backend.common.exception.exceptions
 import com.devpilot.backend.common.exception.CustomException
 import org.springframework.http.HttpStatus
 
-class UserNotFoundException :
-    CustomException(
-        resultCode = "USER_NOT_FOUND",
-        message = "유저를 찾을 수 없습니다.",
-        httpStatus = HttpStatus.UNAUTHORIZED,
-    )
+class UserNotFoundException : CustomException(
+    resultCode = "USER_NOT_FOUND",
+    message = "유저를 찾을 수 없습니다.",
+    httpStatus = HttpStatus.NOT_FOUND,
+)

--- a/src/main/kotlin/com/devpilot/backend/common/service/SignService.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/service/SignService.kt
@@ -1,11 +1,12 @@
 package com.devpilot.backend.common.service
 
 import com.devpilot.backend.common.authority.JwtTokenProvider
+import com.devpilot.backend.common.authority.REFRESH_EXPIRATION_MILLISECONDS
 import com.devpilot.backend.common.authority.TokenInfo
 import com.devpilot.backend.common.dto.CustomSecurityUserDetails
 import com.devpilot.backend.common.dto.TokenDtoRequest
 import com.devpilot.backend.common.entity.MemberRefreshToken
-import com.devpilot.backend.common.exception.InvalidInputException
+import com.devpilot.backend.common.exception.exceptions.TokenValidationException
 import com.devpilot.backend.common.exception.exceptions.UserNotFoundException
 import com.devpilot.backend.common.repository.MemberRefreshTokenRepository
 import com.devpilot.backend.member.entity.Member
@@ -13,7 +14,9 @@ import com.devpilot.backend.member.repository.MemberRepository
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.transaction.Transactional
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import java.util.*
 
 @Service
 class SignService(
@@ -45,34 +48,72 @@ class SignService(
     }
 
     fun newAccessToken(request: TokenDtoRequest, response: HttpServletResponse): TokenInfo {
-        if (!jwtTokenProvider.validateToken(request.refreshToken)) {
-            throw InvalidInputException("로그인이 만료되었습니다.")
+        val refreshToken = request.refreshToken
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw TokenValidationException(
+                resultCode = "REFRESH_TOKEN_INVALID",
+                message = "유효하지 않거나 만료된 Refresh Token입니다.",
+                httpStatus = HttpStatus.UNAUTHORIZED
+            )
         }
 
-        val authentication = jwtTokenProvider.getAuthentication(request.refreshToken)
+        val authentication = jwtTokenProvider.getAuthentication(refreshToken)
         val userId = (authentication.principal as CustomSecurityUserDetails).userId
-            ?: throw InvalidInputException("유저의 아이디가 null일 수 없습니다.")
+            ?: throw TokenValidationException(
+                resultCode = "USER_ID_MISSING_IN_TOKEN",
+                message = "토큰에서 사용자 ID를 찾을 수 없습니다.",
+                httpStatus = HttpStatus.UNAUTHORIZED
+            )
 
-        val storedTokenOpt = memberRefreshTokenRepository.findById(userId)
-        val storedRefreshToken = storedTokenOpt.orElseThrow {
-            InvalidInputException("유효하지 않은 사용자입니다.")
-        }.refreshToken
+        // MemberRefreshToken 엔티티를 사용하는 경우
+        val storedRefreshTokenObj = memberRefreshTokenRepository.findById(userId)
+            .orElseThrow {
+                TokenValidationException(
+                    resultCode = "REFRESH_TOKEN_NOT_FOUND_IN_DB",
+                    message = "데이터베이스에 해당 Refresh Token 정보가 없습니다. 다시 로그인해주세요.",
+                    httpStatus = HttpStatus.UNAUTHORIZED
+                )
+            }
+        val storedRefreshToken = storedRefreshTokenObj.refreshToken
 
-        if (request.refreshToken != storedRefreshToken) {
-            throw InvalidInputException("다시 로그인해주세요")
+        if (refreshToken != storedRefreshToken) {
+            throw TokenValidationException(
+                resultCode = "REFRESH_TOKEN_MISMATCH",
+                message = "유효하지 않은 Refresh Token입니다. 다시 로그인해주세요.",
+                httpStatus = HttpStatus.UNAUTHORIZED
+            )
         }
 
         val newAccessToken = jwtTokenProvider.createAccessToken(authentication)
 
-        val cookie = Cookie("task-pilot-refreshToken", storedRefreshToken).apply {
+        // ✨ Refresh Token 갱신 로직: 만료 임박 또는 재발급 정책에 따라
+        val newRefreshToken: String
+        val refreshTokenClaims = jwtTokenProvider.getClaims(refreshToken)
+        val oneDayInMillis = 1000 * 60 * 60 * 24L // 1일
+
+        // 기존 Refresh Token이 만료 임박(예: 1일 이내)했거나, 재사용 감지 후 무조건 새 토큰 발급 정책 등
+        // `isTokenExpired`는 이미 validateToken에서 체크되므로, 여기서는 만료 임박만 체크해도 됩니다.
+        if (refreshTokenClaims.expiration.time < Date().time + oneDayInMillis) {
+            newRefreshToken = jwtTokenProvider.createRefreshToken(authentication)
+            // DB에 새 Refresh Token 저장
+            storedRefreshTokenObj.refreshToken = newRefreshToken
+            // memberRepository.save(member) // 만약 member 엔티티에 직접 refreshToken을 가지고 있다면
+            memberRefreshTokenRepository.save(storedRefreshTokenObj) // MemberRefreshToken 엔티티 업데이트
+        } else {
+            newRefreshToken = refreshToken // 기존 Refresh Token 재사용
+        }
+
+        val cookie = Cookie("task-pilot-refreshToken", newRefreshToken).apply { // ✨ `newRefreshToken` 사용
             isHttpOnly = true
             secure = true
             path = "/"
-            maxAge = 60 * 60 * 24 * 7
+            maxAge = (REFRESH_EXPIRATION_MILLISECONDS / 1000).toInt()
         }
         response.addCookie(cookie)
 
-        return TokenInfo("Bearer", newAccessToken)
+        // ✨ TokenInfo DTO에 newRefreshToken 포함하여 반환
+        return TokenInfo("Bearer", newAccessToken, newRefreshToken)
     }
 
     fun isAccessTokenExpired(token: String): Boolean {

--- a/src/main/kotlin/com/devpilot/backend/member/service/MemberService.kt
+++ b/src/main/kotlin/com/devpilot/backend/member/service/MemberService.kt
@@ -90,7 +90,7 @@ class MemberService(
         }
         response.addCookie(cookie)
 
-        return TokenInfo("Bearer", accessToken)
+        return TokenInfo("Bearer", accessToken, refreshToken)
     }
 
     /**


### PR DESCRIPTION
- `Task` 엔티티 및 DTO에 `parentId`, `previousStatus` 필드 추가 및 관련 서비스 로직 구현.
- JWT 토큰 갱신 과정 개선:
  - `SignService`에서 `refreshToken` 유효성 검증 및 만료 임박 시 자동 갱신 로직 추가.
  - `AuthenticationController`에서 `GlobalExceptionHandler`로 예외 처리 위임하여 코드 간결화.
- 전역 예외 처리(`GlobalExceptionHandler`) 강화: `CustomException` 계열 예외들을 `BaseResponse` 형식으로 일관되게 반환하며, `404 Not Found` 등 HTTP 상태 코드 세분화.
- `CustomAuthenticationEntryPoint` 수정: `accessToken` 만료 시 JSON 형식의 `BaseResponse` 반환.