### PR TITLE
feat: JWT 토큰 갱신 및 태스크 계층 관계 관리 시스템 강화

### DIFF
--- a/src/main/kotlin/com/devpilot/backend/common/authority/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/authority/CustomAuthenticationEntryPoint.kt
@@ -4,6 +4,7 @@ import com.devpilot.backend.common.dto.BaseResponse
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.core.AuthenticationException
@@ -13,12 +14,18 @@ import java.io.IOException
 class CustomAuthenticationEntryPoint(
     private val objectMapper: ObjectMapper
 ) : AuthenticationEntryPoint {
+
+    private val logger = LoggerFactory.getLogger(JwtTokenProvider::class.java)
+
     @Throws(IOException::class)
     override fun commence(
         request: HttpServletRequest?,
         response: HttpServletResponse,
         authException: AuthenticationException?,
     ) {
+
+        logger.info("CustomAuthenticationEntryPoint called for URI: {}. Auth Exception: {}", request?.requestURI, authException?.message) // ✨ 로그 추가
+
         // 인증 실패 시 (401 Unauthorized) 응답 설정
         response.status = HttpStatus.UNAUTHORIZED.value()
         response.contentType = MediaType.APPLICATION_JSON_VALUE

--- a/src/main/kotlin/com/devpilot/backend/common/controller/AuthenticationController.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/controller/AuthenticationController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.util.UriComponentsBuilder
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.web.bind.annotation.CookieValue
 import java.util.*
 import java.util.stream.Collectors
 
@@ -31,10 +32,10 @@ class AuthenticationController(
 ) {
     @PostMapping("/refresh")
     fun refreshAccessToken(
-        @RequestBody tokenRequestDto: TokenDtoRequest,
+        @CookieValue(name = "task-pilot-refreshToken", required = false) refreshToken: String?,
         response: HttpServletResponse,
     ): BaseResponse<TokenInfo> {
-        val newAccessToken = signService.newAccessToken(tokenRequestDto, response)
+        val newAccessToken = signService.newAccessToken(refreshToken, response)
         return BaseResponse.success(data = newAccessToken)
     }
 

--- a/src/main/kotlin/com/devpilot/backend/common/service/SignService.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/service/SignService.kt
@@ -14,6 +14,7 @@ import com.devpilot.backend.member.repository.MemberRepository
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.transaction.Transactional
+import kotlinx.serialization.MissingFieldException
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import java.util.*
@@ -47,8 +48,15 @@ class SignService(
         }
     }
 
-    fun newAccessToken(request: TokenDtoRequest, response: HttpServletResponse): TokenInfo {
-        val refreshToken = request.refreshToken
+    fun newAccessToken(requestRefreshToken: String?, response: HttpServletResponse): TokenInfo {
+        val refreshToken = requestRefreshToken
+            if(refreshToken.isNullOrBlank()) {
+                throw TokenValidationException(
+                    resultCode = "REFRESH_TOKEN_VALIDATION",
+                    message = "refreshToken은 null일 수 없습니다.",
+                    httpStatus = HttpStatus.BAD_REQUEST
+                )
+            }
 
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw TokenValidationException(


### PR DESCRIPTION
- `Task` 엔티티 및 DTO에 `parentId`, `previousStatus` 필드 추가 및 관련 서비스 로직 구현.
- JWT 토큰 갱신 로직 개선: `refreshToken` 유효성 검증, 만료 임박 시 자동 갱신 및 DB 저장 처리.
- 전역 예외 처리(`GlobalExceptionHandler`) 강화: `CustomException` 계열 예외들을 `BaseResponse` 형식으로 일관되게 반환하며 HTTP 상태 코드 세분화.
- `AuthenticationController` 및 `CustomAuthenticationEntryPoint`에서 토큰 관련 예외 처리를 표준화.