### PR TITLE
fix(#13): 에이전트 API 403 Forbidden 오류 해결 및 보안/오류 응답 개선

### DIFF
--- a/src/main/kotlin/com/devpilot/backend/agent/project/controller/AgentProjectController.kt
+++ b/src/main/kotlin/com/devpilot/backend/agent/project/controller/AgentProjectController.kt
@@ -1,18 +1,20 @@
-package com.devpilot.agent.project.controller
+package com.devpilot.backend.agent.project.controller
 
-import com.devpilot.agent.project.service.AgentProjectService
+import com.devpilot.backend.agent.project.service.AgentProjectService
 import com.devpilot.backend.common.dto.BaseResponse
+import com.devpilot.backend.common.dto.CustomSecurityUserDetails
+import com.devpilot.backend.common.exception.exceptions.UserNotFoundException
 import com.devpilot.backend.project.dto.ProjectRequest
 import com.devpilot.backend.project.dto.ProjectResponse
 import com.devpilot.backend.project.dto.ProjectWithStatusResponse
 import jakarta.validation.Valid
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -27,9 +29,11 @@ class AgentProjectController(
      */
     @PostMapping("/new")
     fun createAgentProject(
-        @RequestHeader("X-User-ID") userId: Long,
         @Valid @RequestBody request: ProjectRequest
     ): BaseResponse<ProjectResponse> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentProjectService.createAgentProject(userId, request)
         return BaseResponse.success(data = response)
     }
@@ -39,7 +43,10 @@ class AgentProjectController(
      * GET /api/agent/projects/mypage
      */
     @GetMapping("/mypage")
-    fun getAllAgentProjectsWithTasks(@RequestHeader("X-User-ID") userId: Long): BaseResponse<List<ProjectWithStatusResponse>> {
+    fun getAllAgentProjectsWithTasks(): BaseResponse<List<ProjectWithStatusResponse>> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentProjectService.getAllAgentProjectsWithTasks(userId)
         return BaseResponse.success(data = response)
     }
@@ -49,7 +56,10 @@ class AgentProjectController(
      * GET /api/agent/projects/dashboard
      */
     @GetMapping("/dashboard")
-    fun getDashboardProjects(@RequestHeader("X-User-ID") userId: Long): BaseResponse<List<ProjectResponse>> {
+    fun getDashboardProjects(): BaseResponse<List<ProjectResponse>> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentProjectService.getDashboardProjects(userId)
         return BaseResponse.success(data = response)
     }
@@ -60,9 +70,11 @@ class AgentProjectController(
      */
     @GetMapping("/{projectId}")
     fun getSingleAgentProjectWithTasks(
-        @RequestHeader("X-User-ID") userId: Long,
         @PathVariable projectId: Long
     ): BaseResponse<ProjectResponse> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentProjectService.getSingleAgentProjectWithTasks(userId, projectId)
         return BaseResponse.success(data = response)
     }
@@ -73,10 +85,12 @@ class AgentProjectController(
      */
     @PutMapping("/{projectId}")
     fun updateAgentProject(
-        @RequestHeader("X-User-ID") userId: Long,
         @PathVariable projectId: Long,
         @Valid @RequestBody request: ProjectRequest
     ): BaseResponse<ProjectResponse> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentProjectService.updateAgentProject(userId, projectId, request)
         return BaseResponse.success(data = response)
     }
@@ -87,9 +101,11 @@ class AgentProjectController(
      */
     @DeleteMapping("/{projectId}")
     fun deleteAgentProject(
-        @RequestHeader("X-User-ID") userId: Long,
         @PathVariable projectId: Long
     ): BaseResponse<Unit> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentProjectService.deleteAgentProject(userId, projectId)
         return BaseResponse.success(data = response)
     }

--- a/src/main/kotlin/com/devpilot/backend/agent/project/service/AgentProjectService.kt
+++ b/src/main/kotlin/com/devpilot/backend/agent/project/service/AgentProjectService.kt
@@ -1,4 +1,4 @@
-package com.devpilot.agent.project.service
+package com.devpilot.backend.agent.project.service
 
 import com.devpilot.backend.project.dto.ProjectRequest
 import com.devpilot.backend.project.dto.ProjectResponse

--- a/src/main/kotlin/com/devpilot/backend/agent/task/controller/AgentTaskController.kt
+++ b/src/main/kotlin/com/devpilot/backend/agent/task/controller/AgentTaskController.kt
@@ -1,7 +1,9 @@
-package com.devpilot.agent.task.controller
+package com.devpilot.backend.agent.task.controller
 
-import com.devpilot.agent.task.service.AgentTaskService
+import com.devpilot.backend.agent.task.service.AgentTaskService
 import com.devpilot.backend.common.dto.BaseResponse
+import com.devpilot.backend.common.dto.CustomSecurityUserDetails
+import com.devpilot.backend.common.exception.exceptions.UserNotFoundException
 import com.devpilot.backend.task.dto.TaskCreateRequest
 import com.devpilot.backend.task.dto.TaskResponse
 import com.devpilot.backend.task.dto.TaskScheduleUpdateRequest
@@ -9,6 +11,7 @@ import com.devpilot.backend.task.dto.TaskStatusUpdateRequest
 import com.devpilot.backend.task.dto.TaskTagUpdateRequest
 import com.devpilot.backend.task.dto.TaskUpdateRequest
 import jakarta.validation.Valid
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -31,9 +34,11 @@ class AgentTaskController(
      */
     @PostMapping("/new")
     fun createAgentTask(
-        @RequestHeader("X-User-ID") userId: Long,
         @Valid @RequestBody request: TaskCreateRequest
     ): BaseResponse<TaskResponse> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentTaskService.createAgentTask(userId, request)
         return BaseResponse.success(data = response)
     }
@@ -43,7 +48,10 @@ class AgentTaskController(
      * GET /api/agent/tasks/all
      */
     @GetMapping("/all")
-    fun getAllAgentTasks(@RequestHeader("X-User-ID") userId: Long): BaseResponse<List<TaskResponse>> {
+    fun getAllAgentTasks(): BaseResponse<List<TaskResponse>> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentTaskService.getAllAgentTasks(userId)
         return BaseResponse.success(data = response)
     }
@@ -54,9 +62,11 @@ class AgentTaskController(
      */
     @GetMapping("/{taskId}")
     fun getSingleAgentTask(
-        @RequestHeader("X-User-ID") userId: Long,
         @PathVariable taskId: Long
     ): BaseResponse<TaskResponse> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentTaskService.getSingleAgentTask(userId, taskId)
         return BaseResponse.success(data = response)
     }
@@ -67,10 +77,12 @@ class AgentTaskController(
      */
     @PutMapping("/{taskId}")
     fun updateAgentTask(
-        @RequestHeader("X-User-ID") userId: Long,
         @PathVariable taskId: Long,
         @Valid @RequestBody request: TaskUpdateRequest
     ): BaseResponse<TaskResponse> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentTaskService.updateAgentTask(userId, taskId, request)
         return BaseResponse.success(data = response)
     }
@@ -81,9 +93,11 @@ class AgentTaskController(
      */
     @DeleteMapping("/{taskId}")
     fun deleteAgentTask(
-        @RequestHeader("X-User-ID") userId: Long,
         @PathVariable taskId: Long
     ): BaseResponse<Unit> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentTaskService.deleteAgentTask(userId, taskId)
         return BaseResponse.success(data = response)
     }
@@ -94,10 +108,12 @@ class AgentTaskController(
      */
     @PatchMapping("/{taskId}/status")
     fun updateAgentTaskStatus(
-        @RequestHeader("X-User-ID") userId: Long,
         @PathVariable taskId: Long,
         @Valid @RequestBody request: TaskStatusUpdateRequest
     ): BaseResponse<TaskResponse> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentTaskService.updateAgentTaskStatus(userId, taskId, request)
         return  BaseResponse.success(data = response)
     }
@@ -108,10 +124,12 @@ class AgentTaskController(
      */
     @PatchMapping("/{taskId}/tags")
     fun updateAgentTaskTags(
-        @RequestHeader("X-User-ID") userId: Long,
         @PathVariable taskId: Long,
         @Valid @RequestBody request: TaskTagUpdateRequest
     ): BaseResponse<TaskResponse> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentTaskService.updateAgentTaskTags(userId, taskId, request)
          return BaseResponse.success(data = response)
     }
@@ -122,10 +140,12 @@ class AgentTaskController(
      */
     @PatchMapping("/{taskId}/schedule")
     fun updateAgentTaskSchedule(
-        @RequestHeader("X-User-ID") userId: Long,
         @PathVariable taskId: Long,
         @Valid @RequestBody request: TaskScheduleUpdateRequest
     ): BaseResponse<TaskResponse> {
+        val userId = (SecurityContextHolder.getContext().authentication.principal as CustomSecurityUserDetails).userId
+            ?: throw UserNotFoundException()
+
         val response = agentTaskService.updateAgentTaskSchedule(userId, taskId, request)
         return BaseResponse.success(data = response)
     }

--- a/src/main/kotlin/com/devpilot/backend/agent/task/service/AgentTaskService.kt
+++ b/src/main/kotlin/com/devpilot/backend/agent/task/service/AgentTaskService.kt
@@ -1,4 +1,4 @@
-package com.devpilot.agent.task.service
+package com.devpilot.backend.agent.task.service
 
 import com.devpilot.backend.task.dto.TaskCreateRequest
 import com.devpilot.backend.task.dto.TaskResponse

--- a/src/main/kotlin/com/devpilot/backend/common/authority/CustomAccessDeniedHandler.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/authority/CustomAccessDeniedHandler.kt
@@ -1,0 +1,48 @@
+package com.devpilot.backend.common.authority
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.stereotype.Component
+import java.io.IOException
+
+@Component
+class CustomAccessDeniedHandler(
+    private val objectMapper: ObjectMapper // 💡 ObjectMapper 주입
+) : AccessDeniedHandler {
+
+    private val logger = LoggerFactory.getLogger(CustomAccessDeniedHandler::class.java)
+
+    @Throws(IOException::class)
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+        val authentication: Authentication? = SecurityContextHolder.getContext().authentication
+        val username = authentication?.name ?: "N/A"
+        val authorities = authentication?.authorities?.map { it.authority } ?: emptyList()
+
+        logger.error("👻 Access Denied: User '{}' with authorities {} tried to access protected resource: '{}'",
+            username, authorities, request.requestURI, accessDeniedException) // 💡 상세 로그
+
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.status = HttpStatus.FORBIDDEN.value() // 403 Forbidden
+
+        val errorResponse = mutableMapOf<String, Any>()
+        errorResponse["resultCode"] = "ACCESS_DENIED"
+        errorResponse["message"] = "접근 권한이 없습니다. (인증은 되었으나, 해당 리소스에 대한 권한 없음)"
+//        errorResponse["data"] = null
+        errorResponse["httpStatus"] = HttpStatus.FORBIDDEN.value()
+
+        response.writer.write(objectMapper.writeValueAsString(errorResponse))
+        response.writer.flush()
+    }
+}

--- a/src/main/kotlin/com/devpilot/backend/common/authority/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/authority/CustomAuthenticationEntryPoint.kt
@@ -1,28 +1,37 @@
 package com.devpilot.backend.common.authority
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.security.core.AuthenticationException
 import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
 import java.io.IOException
 
-class CustomAuthenticationEntryPoint : AuthenticationEntryPoint {
+class CustomAuthenticationEntryPoint(
+    private val objectMapper: ObjectMapper
+) : AuthenticationEntryPoint {
+
+    constructor() : this(ObjectMapper())
+
     @Throws(IOException::class)
     override fun commence(
         request: HttpServletRequest?,
         response: HttpServletResponse,
         authException: AuthenticationException?,
     ) {
-//        // 리디렉션 URL 설정
-//        val redirectUrl = "/api/member/login"
-//
-//        println("redirect to login")
-//
-//        // 클라이언트로 리디렉션
-//        response.sendRedirect(redirectUrl)
-//
-        // 401 상태 코드와 메시지를 클라이언트로 전송
-        response.sendError(HttpStatus.UNAUTHORIZED.value(), "Unauthorized: Token has expired.")
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.status = HttpStatus.UNAUTHORIZED.value()
+
+        val errorResponse = mutableMapOf<String, Any>()
+        errorResponse["resultCode"] = "ACCESS_TOKEN_EXPIRED"
+        errorResponse["message"] = "Unauthorized: Token has expired. Please log in again."
+//        errorResponse["data"] = null
+        errorResponse["httpStatus"] = HttpStatus.UNAUTHORIZED.value()
+
+        response.writer.write(objectMapper.writeValueAsString(errorResponse))
+        response.writer.flush()
     }
 }

--- a/src/main/kotlin/com/devpilot/backend/common/authority/SecurityConfig.kt
+++ b/src/main/kotlin/com/devpilot/backend/common/authority/SecurityConfig.kt
@@ -30,9 +30,10 @@ class SecurityConfig(
     private val customOidcUserService: CustomOidcUserService,
     private val oAuth2SuccessHandler: OAuth2SuccessHandler,
     private val oAuth2FailureHandler: OAuth2FailureHandler,
+    private val customAccessDeniedHandler: CustomAccessDeniedHandler,
 ) {
     @Bean
-    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+    fun filterChain(http: HttpSecurity, customAccessDeniedHandler: CustomAccessDeniedHandler): SecurityFilterChain {
         http
             .httpBasic { it.disable() }
             .csrf { it.disable() }
@@ -59,15 +60,18 @@ class SecurityConfig(
                         "/api/task/**",
                         "/api/project/**",
                         "/api/member/**",
-                        "/api/auth/bind/google"
+                        "/api/auth/bind/google",
+                        "/api/agent/**"
                     ).hasRole("MEMBER")
                     .requestMatchers(
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/oauth2/**",
-                        "/api/agent/**" // LLM에 대한 로직은 일단 열어두기
                     ).permitAll()
-            }.exceptionHandling { it.authenticationEntryPoint(customAuthenticationEntryPoint()) }
+            }.exceptionHandling {
+                it.authenticationEntryPoint(customAuthenticationEntryPoint())
+                it.accessDeniedHandler(customAccessDeniedHandler)
+            }
             .addFilterBefore(
                 rateLimitFilter,
                 SecurityContextHolderAwareRequestFilter::class.java,


### PR DESCRIPTION
- 에이전트 관련 컴포넌트들의 패키지 구조를 `com.devpilot.agent`에서 `com.devpilot.backend.agent`로 변경하여 Spring Boot의 **컴포넌트 스캔 문제**를 해결했습니다.
  - 이로 인해 `AgentProjectController` 등 에이전트 컴포넌트들이 Spring 컨텍스트에 정상적으로 빈으로 등록되지 않아 발생하던 403 Forbidden (인가 실패) 오류가 해결되었습니다.
  - 요청이 컨트롤러에 도달하지 못하고 인가 필터에서 차단되던 문제가 해소되었습니다.
- `SecurityConfig`에 `CustomAccessDeniedHandler`를 적용하여 인증된 사용자가 권한 없는 리소스에 접근 시 발생하는 **인가 거부(403) 오류 응답을 사용자 친화적인 JSON 형식으로 제공**하도록 개선했습니다.
  - `/error` 경로에 대한 `permitAll()` 설정을 유지하여 상세 오류 로그 확인을 용이하게 했습니다.
- `CustomAuthenticationEntryPoint`를 `ObjectMapper`를 사용하여 리팩토링하여 **인증 실패(401) 응답도 표준 JSON 형식으로 반환**하도록 변경했습니다.
- `AgentProjectController` 내부의 디버깅용 상세 로그 및 임시 예외 처리 로직을 제거하여 코드를 정리했습니다.
- `/api/agent/**` 경로에 대한 접근 권한을 `permitAll()`에서 `hasRole("MEMBER")`로 **원래의 보안 설정으로 복구**했습니다.